### PR TITLE
make doLink public to patch broken windows builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -117,7 +117,7 @@ pub fn link(b: *Build, step: *std.build.CompileStep, options: Options) void {
     step.step.dependOn(&link_step.step);
 }
 
-fn doLink(b: *Build, step: *std.build.CompileStep, options: Options) !void {
+pub fn doLink(b: *Build, step: *std.build.CompileStep, options: Options) !void {
     const opt = options.detectDefaults(step.target_info.target);
 
     if (step.target_info.target.os.tag == .windows) @import("direct3d_headers").addLibraryPath(step);


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

The self-injecting link step is causing this issue https://github.com/hexops/mach/issues/1012. This PR enables a low-hanging fruit mitigation by exposing `doLink` so it can be used directly from the dependents build scripts