### PR TITLE
update zig: fixed deprecated method for fs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1616,7 +1616,7 @@ fn scanSources(
     excluding_contains: []const []const u8,
 ) !void {
     const abs_dir = try std.fs.path.join(b.allocator, &.{ sdkPath("/"), rel_dir });
-    var dir = std.fs.openIterableDirAbsolute(abs_dir, .{}) catch |err| {
+    var dir = std.fs.openDirAbsolute(abs_dir, .{}) catch |err| {
         std.log.err("mach: error: failed to open: {s}", .{abs_dir});
         return err;
     };


### PR DESCRIPTION
Updated depreciated function for fs

https://github.com/ziglang/zig/commit/519ba9bb654a4d5caf7440160f018b7a3ae1e95a#diff-f01c086c6578a4706cb6bf136d56fb04a344ed23735bbaf1c51976cfc384eac5L2837

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.